### PR TITLE
Removed Print statement from `codeText.swift`

### DIFF
--- a/Sources/HighlightSwift/HighlightViews/CodeText.swift
+++ b/Sources/HighlightSwift/HighlightViews/CodeText.swift
@@ -81,7 +81,6 @@ public struct CodeText {
             }
             await MainActor.run {
                 self.result = result
-                print(result)
                 withAnimation {
                     self.attributedText = result.attributedText
                 }


### PR DESCRIPTION
When successfully invoking the `highlightText` function, the print statement logs the entirety of the result of the call, leading to an overbearing amount of log entries. 

